### PR TITLE
Created application/json login endpoint

### DIFF
--- a/portofino-core/src/main/java/com/manydesigns/portofino/resourceactions/login/DefaultLoginAction.java
+++ b/portofino-core/src/main/java/com/manydesigns/portofino/resourceactions/login/DefaultLoginAction.java
@@ -89,9 +89,26 @@ public class DefaultLoginAction extends AbstractResourceAction {
     public MailQueue mailQueue;
 
     @POST
-    @Produces("application/json")
-    public String login(@FormParam("username") String username, @FormParam("password") String password)
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response login(@FormParam("username") String username, @FormParam("password") String password)
             throws AuthenticationException {
+        return Response.ok(doLogin(username, password)).build();
+    }
+
+    public static class LoginData {
+        public String username;
+        public String password;
+    }
+
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response login(LoginData data) {
+        return Response.ok(doLogin(data.username, data.password)).build();
+    }
+
+    private String doLogin(String username, String password) {
         Subject subject = SecurityUtils.getSubject();
         if(!subject.isAuthenticated()) try {
             UsernamePasswordToken usernamePasswordToken = new UsernamePasswordToken(username, password);


### PR DESCRIPTION
The DefaultLoginAction provides a login endpoint that only consumes a content-type application / x-www-form-urlencoded, forcing the developer to specify it in the request.
This endpoint, in my opinion, is more in line with the front-end and back-end separation policy of version 5.