### PR TITLE
Feature/multitenancy2.0

### DIFF
--- a/portofino-database/src/main/java/com/manydesigns/portofino/database/multitenancy/MultiTenant.java
+++ b/portofino-database/src/main/java/com/manydesigns/portofino/database/multitenancy/MultiTenant.java
@@ -1,0 +1,6 @@
+package com.manydesigns.portofino.database.multitenancy;
+
+public @interface MultiTenant {
+
+    Class strategy();
+}

--- a/portofino-database/src/main/java/com/manydesigns/portofino/persistence/Persistence.java
+++ b/portofino-database/src/main/java/com/manydesigns/portofino/persistence/Persistence.java
@@ -23,6 +23,7 @@ package com.manydesigns.portofino.persistence;
 import com.manydesigns.portofino.PortofinoProperties;
 import com.manydesigns.portofino.cache.CacheResetEvent;
 import com.manydesigns.portofino.cache.CacheResetListenerRegistry;
+import com.manydesigns.portofino.database.multitenancy.MultiTenant;
 import com.manydesigns.portofino.liquibase.VFSResourceAccessor;
 import com.manydesigns.portofino.model.Model;
 import com.manydesigns.portofino.model.database.*;
@@ -31,6 +32,7 @@ import com.manydesigns.portofino.modules.DatabaseModule;
 import com.manydesigns.portofino.persistence.hibernate.HibernateDatabaseSetup;
 import com.manydesigns.portofino.persistence.hibernate.SessionFactoryAndCodeBase;
 import com.manydesigns.portofino.persistence.hibernate.SessionFactoryBuilder;
+import com.manydesigns.portofino.persistence.hibernate.multitenancy.MultiTenancyImplementation;
 import com.manydesigns.portofino.reflection.TableAccessor;
 import com.manydesigns.portofino.reflection.ViewAccessor;
 import com.manydesigns.portofino.sync.DatabaseSyncer;
@@ -49,6 +51,7 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.FileType;
+import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.Session;
 import org.hibernate.Transaction;
 import org.jetbrains.annotations.NotNull;
@@ -59,12 +62,11 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
-import java.io.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.sql.Connection;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
+import java.util.*;
 
 /**
  * @author Paolo Predonzani     - paolo.predonzani@manydesigns.com
@@ -409,12 +411,14 @@ public class Persistence {
             ConnectionProvider connectionProvider = database.getConnectionProvider();
             connectionProvider.init(databasePlatformsRegistry);
             if (connectionProvider.getStatus().equals(ConnectionProvider.STATUS_CONNECTED)) {
-                SessionFactoryBuilder builder = new SessionFactoryBuilder(database);
+                MultiTenancyImplementation implementation = getMultiTenancyImplementation(database);
+                SessionFactoryBuilder builder = new SessionFactoryBuilder(database, configuration, implementation);
                 SessionFactoryAndCodeBase sessionFactoryAndCodeBase = builder.buildSessionFactory();
                 HibernateDatabaseSetup setup =
                         new HibernateDatabaseSetup(
                                 database, sessionFactoryAndCodeBase.sessionFactory,
-                                sessionFactoryAndCodeBase.codeBase, builder.getEntityMode());
+                                sessionFactoryAndCodeBase.codeBase, builder.getEntityMode(), configuration,
+                                implementation);
                 String databaseName = database.getDatabaseName();
                 HibernateDatabaseSetup oldSetup = setups.get(databaseName);
                 setups.put(databaseName, setup);
@@ -428,6 +432,27 @@ public class Persistence {
         } catch (Exception e) {
             logger.error("Could not create connection provider for " + database, e);
         }
+    }
+
+    protected MultiTenancyImplementation getMultiTenancyImplementation(Database database) {
+        Optional<MultiTenant> multiTenant = database.getJavaAnnotation(MultiTenant.class);
+        if(multiTenant.isPresent()) {
+            Class<MultiTenancyImplementation> implClass = multiTenant.get().strategy();
+            //TODO injection?
+            if(!MultiTenancyImplementation.class.isAssignableFrom(implClass)) {
+                throw new ClassCastException(implClass + " does not extend " + MultiTenancyImplementation.class);
+            }
+            try {
+                MultiTenancyImplementation implementation = implClass.getConstructor().newInstance();
+                MultiTenancyStrategy strategy = implementation.getStrategy();
+                if (strategy.requiresMultiTenantConnectionProvider()) {
+                    return implementation;
+                }
+            } catch (Exception e) {
+                throw new RuntimeException("Could not instantiate multi tenancy implementation " + implClass + " for " + database, e);
+            }
+        }
+        return null;
     }
 
     public void retryFailedConnections() {
@@ -580,6 +605,8 @@ public class Persistence {
             connectionProvider.shutdown();
         }
         status.onNext(Status.STOPPED);
+        databaseSetupEvents.onComplete();
+        status.onComplete();
     }
 
     //**************************************************************************

--- a/portofino-database/src/main/java/com/manydesigns/portofino/persistence/Persistence.java
+++ b/portofino-database/src/main/java/com/manydesigns/portofino/persistence/Persistence.java
@@ -418,7 +418,7 @@ public class Persistence {
                         new HibernateDatabaseSetup(
                                 database, sessionFactoryAndCodeBase.sessionFactory,
                                 sessionFactoryAndCodeBase.codeBase, builder.getEntityMode(), configuration,
-                                implementation);
+                                implementation, this);
                 String databaseName = database.getDatabaseName();
                 HibernateDatabaseSetup oldSetup = setups.get(databaseName);
                 setups.put(databaseName, setup);
@@ -443,7 +443,8 @@ public class Persistence {
                 throw new ClassCastException(implClass + " does not extend " + MultiTenancyImplementation.class);
             }
             try {
-                MultiTenancyImplementation implementation = implClass.getConstructor().newInstance();
+//                MultiTenancyImplementation implementation = implClass.getConstructor().newInstance();
+                MultiTenancyImplementation implementation = implClass.getConstructor(Persistence.class).newInstance(this);
                 MultiTenancyStrategy strategy = implementation.getStrategy();
                 if (strategy.requiresMultiTenantConnectionProvider()) {
                     return implementation;

--- a/portofino-database/src/main/java/com/manydesigns/portofino/persistence/hibernate/HibernateDatabaseSetup.java
+++ b/portofino-database/src/main/java/com/manydesigns/portofino/persistence/hibernate/HibernateDatabaseSetup.java
@@ -22,6 +22,7 @@ package com.manydesigns.portofino.persistence.hibernate;
 
 import com.manydesigns.portofino.code.CodeBase;
 import com.manydesigns.portofino.model.database.Database;
+import com.manydesigns.portofino.persistence.Persistence;
 import com.manydesigns.portofino.persistence.hibernate.multitenancy.MultiTenancyImplementation;
 import org.apache.commons.configuration2.Configuration;
 import org.hibernate.EntityMode;
@@ -51,19 +52,21 @@ public class HibernateDatabaseSetup {
     protected final Configuration configuration;
     protected final Map<String, String> jpaEntityNameToClassNameMap = new HashMap<>();
     protected final MultiTenancyImplementation multiTenancyImplementation;
+    protected final Persistence persistence;
 
         public static final Logger logger =
             LoggerFactory.getLogger(HibernateDatabaseSetup.class);
 
     public HibernateDatabaseSetup(
             Database database, SessionFactory sessionFactory, CodeBase codeBase, EntityMode entityMode,
-            Configuration configuration, MultiTenancyImplementation multiTenancyImplementation) {
+            Configuration configuration, MultiTenancyImplementation multiTenancyImplementation, Persistence persistence) {
         this.database = database;
         this.sessionFactory = sessionFactory;
         this.codeBase = codeBase;
         this.entityMode = entityMode;
         this.configuration = configuration;
         this.multiTenancyImplementation = multiTenancyImplementation;
+        this.persistence = persistence;
         threadSessions = new ThreadLocal<>();
         database.getAllTables().forEach(t -> {
             jpaEntityNameToClassNameMap.put(t.getActualEntityName(), SessionFactoryBuilder.getMappedClassName(t, entityMode));

--- a/portofino-database/src/main/java/com/manydesigns/portofino/persistence/hibernate/HibernateDatabaseSetup.java
+++ b/portofino-database/src/main/java/com/manydesigns/portofino/persistence/hibernate/HibernateDatabaseSetup.java
@@ -22,7 +22,11 @@ package com.manydesigns.portofino.persistence.hibernate;
 
 import com.manydesigns.portofino.code.CodeBase;
 import com.manydesigns.portofino.model.database.Database;
-import org.hibernate.*;
+import com.manydesigns.portofino.persistence.hibernate.multitenancy.MultiTenancyImplementation;
+import org.apache.commons.configuration2.Configuration;
+import org.hibernate.EntityMode;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,16 +48,22 @@ public class HibernateDatabaseSetup {
     protected final CodeBase codeBase;
     protected final ThreadLocal<Session> threadSessions;
     protected final EntityMode entityMode;
+    protected final Configuration configuration;
     protected final Map<String, String> jpaEntityNameToClassNameMap = new HashMap<>();
+    protected final MultiTenancyImplementation multiTenancyImplementation;
 
         public static final Logger logger =
             LoggerFactory.getLogger(HibernateDatabaseSetup.class);
 
-    public HibernateDatabaseSetup(Database database, SessionFactory sessionFactory, CodeBase codeBase, EntityMode entityMode) {
+    public HibernateDatabaseSetup(
+            Database database, SessionFactory sessionFactory, CodeBase codeBase, EntityMode entityMode,
+            Configuration configuration, MultiTenancyImplementation multiTenancyImplementation) {
         this.database = database;
         this.sessionFactory = sessionFactory;
         this.codeBase = codeBase;
         this.entityMode = entityMode;
+        this.configuration = configuration;
+        this.multiTenancyImplementation = multiTenancyImplementation;
         threadSessions = new ThreadLocal<>();
         database.getAllTables().forEach(t -> {
             jpaEntityNameToClassNameMap.put(t.getActualEntityName(), SessionFactoryBuilder.getMappedClassName(t, entityMode));
@@ -86,7 +96,12 @@ public class HibernateDatabaseSetup {
     }
 
     public Session createSession() {
-        Session session = sessionFactory.openSession();
+        Session session;
+        if(multiTenancyImplementation != null) {
+            session = sessionFactory.withOptions().tenantIdentifier(multiTenancyImplementation.getTenant()).openSession();
+        } else {
+            session = sessionFactory.openSession();
+        }
         return new SessionDelegator(this, session);
     }
 
@@ -119,5 +134,9 @@ public class HibernateDatabaseSetup {
 
     public EntityMode getEntityMode() {
         return entityMode;
+    }
+
+    public MultiTenancyImplementation getMultiTenancyImplementation() {
+        return multiTenancyImplementation;
     }
 }

--- a/portofino-database/src/main/java/com/manydesigns/portofino/persistence/hibernate/SessionFactoryBuilder.java
+++ b/portofino-database/src/main/java/com/manydesigns/portofino/persistence/hibernate/SessionFactoryBuilder.java
@@ -10,17 +10,20 @@ import com.manydesigns.portofino.model.database.Table;
 import com.manydesigns.portofino.model.database.TableGenerator;
 import com.manydesigns.portofino.model.database.*;
 import com.manydesigns.portofino.model.database.platforms.DatabasePlatform;
+import com.manydesigns.portofino.persistence.hibernate.multitenancy.MultiTenancyImplementation;
 import javassist.*;
 import javassist.bytecode.AnnotationsAttribute;
 import javassist.bytecode.ClassFile;
 import javassist.bytecode.ConstPool;
 import javassist.bytecode.annotation.*;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.vfs2.FileName;
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
 import org.apache.commons.vfs2.VFS;
 import org.hibernate.EntityMode;
+import org.hibernate.MultiTenancyStrategy;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Immutable;
 import org.hibernate.annotations.TypeDef;
@@ -30,8 +33,10 @@ import org.hibernate.boot.MetadataBuilder;
 import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.registry.BootstrapServiceRegistry;
 import org.hibernate.boot.registry.BootstrapServiceRegistryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.boot.registry.classloading.internal.ClassLoaderServiceImpl;
+import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.mapping.Component;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.service.ServiceRegistry;
@@ -62,6 +67,8 @@ public class SessionFactoryBuilder {
     protected String falseString = "F";
     protected final Database database;
     protected final ClassPool classPool = new ClassPool(ClassPool.getDefault());
+    protected final Configuration configuration;
+    protected final MultiTenancyImplementation multiTenancyImplementation;
     protected EntityMode entityMode = EntityMode.MAP;
 
     protected static final Set<String> JAVA_KEYWORDS = new HashSet<>();
@@ -72,8 +79,11 @@ public class SessionFactoryBuilder {
         JAVA_KEYWORDS.add("public");
     }
 
-    public SessionFactoryBuilder(Database database) {
+    public SessionFactoryBuilder(
+            Database database, Configuration configuration, MultiTenancyImplementation multiTenancyImplementation) {
         this.database = database;
+        this.configuration = configuration;
+        this.multiTenancyImplementation = multiTenancyImplementation;
         String trueString = database.getTrueString();
         if (trueString != null) {
             this.trueString = "null".equalsIgnoreCase(trueString) ? null : trueString;
@@ -241,35 +251,70 @@ public class SessionFactoryBuilder {
         ConnectionProvider connectionProvider = database.getConnectionProvider();
         if(!connectionProvider.isHibernateDialectAutodetected()) {
             settings.put(
-                    "hibernate.dialect",
+                    AvailableSettings.DIALECT,
                     connectionProvider.getActualHibernateDialectName());
         }
-        if(connectionProvider instanceof JdbcConnectionProvider) {
-            JdbcConnectionProvider jdbcConnectionProvider =
-                    (JdbcConnectionProvider) connectionProvider;
-            settings.put("hibernate.connection.url", jdbcConnectionProvider.getActualUrl());
-            String driver = jdbcConnectionProvider.getDriver();
-            if(driver != null) {
-                settings.put("hibernate.connection.driver_class", driver);
+        settings.put(AvailableSettings.JPA_METAMODEL_POPULATION, "enabled");
+        if (multiTenancyImplementation != null) {
+            MultiTenancyStrategy strategy = multiTenancyImplementation.getStrategy();
+            if (strategy.requiresMultiTenantConnectionProvider()) {
+                setupMultiTenantConnection(connectionProvider, settings);
+            } else {
+                setupSingleTenantConnection(connectionProvider, settings);
             }
-            if(jdbcConnectionProvider.getActualUsername() != null) {
-                settings.put("hibernate.connection.username", jdbcConnectionProvider.getActualUsername());
-            }
-            if(jdbcConnectionProvider.getActualPassword() != null) {
-                settings.put("hibernate.connection.password", jdbcConnectionProvider.getActualPassword());
-            }
-        } else if(connectionProvider instanceof JndiConnectionProvider) {
-            JndiConnectionProvider jndiConnectionProvider =
-                    (JndiConnectionProvider) connectionProvider;
-            settings.put("hibernate.connection.datasource", jndiConnectionProvider.getJndiResource());
         } else {
-            throw new Error("Unsupported connection provider: " + connectionProvider);
+            setupSingleTenantConnection(connectionProvider, settings);
         }
-        settings.put("hibernate.ejb.metamodel.population", "enabled");
         //TODO evaluate if they're still applicable:
         //  .setProperty("hibernate.current_session_context_class", "org.hibernate.context.internal.ThreadLocalSessionContext")
         //  .setProperty("org.hibernate.hql.ast.AST", "true")
         //  .setProperty("hibernate.globally_quoted_identifiers", "false");
+    }
+
+    protected void setupMultiTenantConnection(ConnectionProvider connectionProvider, Map<String, Object> settings) {
+        if(connectionProvider instanceof JndiConnectionProvider) {
+            logger.debug("JNDI connection provider configured. Using default Hibernate strategy based on JNDI (org.hibernate.engine.jdbc.connections.spi.DataSourceBasedMultiTenantConnectionProviderImpl).");
+            return;
+        }
+
+        setupSingleTenantConnection(connectionProvider, settings);
+
+        BootstrapServiceRegistryBuilder bootstrapRegistryBuilder = new BootstrapServiceRegistryBuilder();
+        BootstrapServiceRegistry bootstrapServiceRegistry = bootstrapRegistryBuilder.build();
+        Class<?> connectionProviderClass;
+        try(StandardServiceRegistry standardRegistry =
+                    new StandardServiceRegistryBuilder(bootstrapServiceRegistry).applySettings(settings).build()) {
+            Object service = standardRegistry.getService(org.hibernate.engine.jdbc.connections.spi.ConnectionProvider.class);
+            connectionProviderClass = service.getClass();
+        }
+
+        settings.put(MultiTenancyImplementation.CONNECTION_PROVIDER_CLASS, connectionProviderClass);
+        settings.put(AvailableSettings.MULTI_TENANT_CONNECTION_PROVIDER, multiTenancyImplementation.getClass());
+        settings.put(AvailableSettings.MULTI_TENANT, multiTenancyImplementation.getStrategy());
+    }
+
+    protected void setupSingleTenantConnection(ConnectionProvider connectionProvider, Map<String, Object> settings) {
+        if(connectionProvider instanceof JdbcConnectionProvider) {
+            JdbcConnectionProvider jdbcConnectionProvider =
+                    (JdbcConnectionProvider) connectionProvider;
+            settings.put(AvailableSettings.URL, jdbcConnectionProvider.getActualUrl());
+            String driver = jdbcConnectionProvider.getDriver();
+            if(driver != null) {
+                settings.put(AvailableSettings.DRIVER, driver);
+            }
+            if(jdbcConnectionProvider.getActualUsername() != null) {
+                settings.put(AvailableSettings.USER, jdbcConnectionProvider.getActualUsername());
+            }
+            if(jdbcConnectionProvider.getActualPassword() != null) {
+                settings.put(AvailableSettings.PASS, jdbcConnectionProvider.getActualPassword());
+            }
+        } else if(connectionProvider instanceof JndiConnectionProvider) {
+            JndiConnectionProvider jndiConnectionProvider =
+                    (JndiConnectionProvider) connectionProvider;
+            settings.put(AvailableSettings.DATASOURCE, jndiConnectionProvider.getJndiResource());
+        } else {
+            throw new Error("Unsupported connection provider: " + connectionProvider);
+        }
     }
 
     protected FileObject getEntityLocation(FileObject root, Table table) throws FileSystemException {
@@ -443,10 +488,13 @@ public class SessionFactoryBuilder {
     protected void configureAnnotations(Table table, ConstPool constPool, AnnotationsAttribute classAnnotations) {
         Annotation annotation;
 
-        String schemaName = table.getSchema().getActualSchemaName();
         annotation = new Annotation(javax.persistence.Table.class.getName(), constPool);
         annotation.addMemberValue("name", new StringMemberValue(jpaEscape(table.getTableName()), constPool));
-        annotation.addMemberValue("schema", new StringMemberValue(jpaEscape(schemaName), constPool));
+        if (multiTenancyImplementation == null || multiTenancyImplementation.getStrategy() != MultiTenancyStrategy.SCHEMA) {
+            //Don't configure the schema name if we're using schema-based multitenancy
+            String schemaName = table.getSchema().getActualSchemaName();
+            annotation.addMemberValue("schema", new StringMemberValue(jpaEscape(schemaName), constPool));
+        }
         classAnnotations.addAnnotation(annotation);
 
         annotation = new Annotation(Entity.class.getName(), constPool);

--- a/portofino-database/src/main/java/com/manydesigns/portofino/persistence/hibernate/multitenancy/MultiTenancyImplementation.java
+++ b/portofino-database/src/main/java/com/manydesigns/portofino/persistence/hibernate/multitenancy/MultiTenancyImplementation.java
@@ -1,0 +1,142 @@
+package com.manydesigns.portofino.persistence.hibernate.multitenancy;
+
+import org.hibernate.MultiTenancyStrategy;
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.engine.jdbc.connections.spi.AbstractMultiTenantConnectionProvider;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.service.spi.*;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * This class has two purposes:
+ * <ol>
+ *     <li>act as an AbstractMultiTenantConnectionProvider for Hibernate, selecting a different connection provider
+ *     for each tenant;</li>
+ *     <li>act as a strategy for Portofino to compute the current tenant.</li>
+ * </ol>
+ * Given that the two purposes have overlapping needs, and we can't use inner classes (because this will be instantiated
+ * reflectively both by Portofino and by Hibernate), we've settled on a single class even if it's not properly designed
+ * OO.
+ * Implementors should keep in mind that two instances will be created to perform the two different tasks,
+ * and they will not share state.
+ */
+public abstract class MultiTenancyImplementation extends AbstractMultiTenantConnectionProvider
+        implements ServiceRegistryAwareService, Configurable, Stoppable {
+
+    public static final String CONNECTION_PROVIDER_CLASS = "portofino.persistence.hibernate.multitenancy.connectionProviderClass";
+    private static final Logger logger = LoggerFactory.getLogger(MultiTenancyImplementation.class);
+
+    private Class<ConnectionProvider> connectionProviderClass;
+
+    private ServiceRegistryImplementor serviceRegistry;
+    private Map configurationValues;
+    private final ConcurrentMap<Object, ConnectionProvider> connectionProviders = new ConcurrentHashMap<>();
+
+    public MultiTenancyImplementation() {
+    }
+
+    public MultiTenancyStrategy getStrategy() {
+        return MultiTenancyStrategy.DATABASE;
+    }
+
+    @Override
+    protected ConnectionProvider getAnyConnectionProvider() {
+        return getConnectionProvider(getDefaultTenant(), configurationValues);
+    }
+
+    public String getDefaultTenant() {
+        return "portofino";
+    }
+
+    public abstract String getTenant();
+
+    @Override
+    protected ConnectionProvider selectConnectionProvider(String tenantIdentifier) {
+        Map settings = new HashMap(configurationValues);
+        return getConnectionProvider(tenantIdentifier, settings);
+    }
+
+    @NotNull
+    protected ConnectionProvider getConnectionProvider(String tenant, Map configuration) {
+        return connectionProviders.computeIfAbsent(tenant, o -> createConnectionProvider(tenant, configuration));
+    }
+
+    @NotNull
+    protected ConnectionProvider createConnectionProvider(String tenant, Map configuration) {
+        ConnectionProvider connectionProvider;
+        try {
+            connectionProvider = connectionProviderClass.getConstructor().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not instantiate connection provider " + connectionProviderClass, e);
+        }
+        String url = getConnectionURL(tenant);
+        if (url != null) {
+            configuration.put(AvailableSettings.URL, url);
+        }
+        String username = getUsername(tenant);
+        if (username != null) {
+            configuration.put(AvailableSettings.USER, username);
+        }
+        String password = getPassword(tenant);
+        if (password != null) {
+            configuration.put(AvailableSettings.PASS, username);
+        }
+        if (connectionProvider instanceof ServiceRegistryAwareService) {
+            ((ServiceRegistryAwareService) connectionProvider).injectServices(serviceRegistry);
+        }
+        if (connectionProvider instanceof Configurable) {
+            ((Configurable) connectionProvider).configure(configuration);
+        }
+        if (connectionProvider instanceof Startable) {
+            ((Startable) connectionProvider).start();
+        }
+        return connectionProvider;
+    }
+
+    public String getConnectionURL(String tenant) {
+        return null;
+    }
+
+    public String getUsername(String tenant) {
+        return null;
+    }
+
+    public String getPassword(String tenant) {
+        return null;
+    }
+
+    @Override
+    public void injectServices(ServiceRegistryImplementor serviceRegistry) {
+        this.serviceRegistry = serviceRegistry;
+    }
+
+    @Override
+    public void configure(Map configurationValues) {
+        this.configurationValues = configurationValues;
+        connectionProviderClass = (Class<ConnectionProvider>) configurationValues.get(CONNECTION_PROVIDER_CLASS);
+        if (!ConnectionProvider.class.isAssignableFrom(connectionProviderClass)) {
+            throw new RuntimeException("Class " + connectionProviderClass.getName() + " does not implement ConnectionProvider");
+        }
+    }
+
+    @Override
+    public void stop() {
+        connectionProviders.values().forEach(cp -> {
+            if (cp instanceof Stoppable) {
+                try {
+                    ((Stoppable) cp).stop();
+                } catch (Exception e) {
+                    logger.warn("Could not stop connection provider " + cp, e);
+                }
+            }
+        });
+        connectionProviders.clear();
+    }
+}

--- a/portofino-database/src/main/java/com/manydesigns/portofino/persistence/hibernate/multitenancy/SchemaBasedMultiTenancy.java
+++ b/portofino-database/src/main/java/com/manydesigns/portofino/persistence/hibernate/multitenancy/SchemaBasedMultiTenancy.java
@@ -1,0 +1,63 @@
+package com.manydesigns.portofino.persistence.hibernate.multitenancy;
+
+import org.hibernate.MultiTenancyStrategy;
+import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.jetbrains.annotations.NotNull;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Map;
+
+public abstract class SchemaBasedMultiTenancy extends MultiTenancyImplementation {
+
+    @Override
+    public MultiTenancyStrategy getStrategy() {
+        return MultiTenancyStrategy.SCHEMA;
+    }
+
+    @NotNull
+    @Override
+    protected ConnectionProvider createConnectionProvider(String tenant, Map configuration) {
+        ConnectionProvider delegate = super.createConnectionProvider(tenant, configuration);
+        return new ConnectionProviderWithSchemaPerTenant(delegate, tenant);
+    }
+
+    protected abstract void setSchema(Connection connection, String tenant) throws SQLException;
+
+    public class ConnectionProviderWithSchemaPerTenant implements ConnectionProvider {
+        private final ConnectionProvider delegate;
+        private final String tenant;
+
+        public ConnectionProviderWithSchemaPerTenant(ConnectionProvider delegate, String tenant) {
+            this.delegate = delegate;
+            this.tenant = tenant;
+        }
+
+        @Override
+        public Connection getConnection() throws SQLException {
+            Connection connection = delegate.getConnection();
+            setSchema(connection, tenant);
+            return connection;
+        }
+
+        @Override
+        public void closeConnection(Connection conn) throws SQLException {
+            delegate.closeConnection(conn);
+        }
+
+        @Override
+        public boolean supportsAggressiveRelease() {
+            return delegate.supportsAggressiveRelease();
+        }
+
+        @Override
+        public boolean isUnwrappableAs(Class unwrapType) {
+            return delegate.isUnwrappableAs(unwrapType);
+        }
+
+        @Override
+        public <T> T unwrap(Class<T> unwrapType) {
+            return delegate.unwrap(unwrapType);
+        }
+    }
+}

--- a/portofino-model/src/main/java/com/manydesigns/portofino/model/database/Database.java
+++ b/portofino-model/src/main/java/com/manydesigns/portofino/model/database/Database.java
@@ -76,7 +76,7 @@ public class Database implements ModelObject, Annotated {
     }
 
     //**************************************************************************
-    // DatamodelObject implementation
+    // ModelObject implementation
     //**************************************************************************
 
     public void afterUnmarshal(Unmarshaller u, Object parent) {}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -3490,7 +3490,7 @@
     },
     "@types/q": {
       "version": "0.0.32",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
+      "resolved": "http://registry.npmjs.org/@types/q/-/q-0.0.32.tgz",
       "integrity": "sha1-vShOV8hPEyXacCur/IKlMoGQwMU=",
       "dev": true
     },
@@ -13069,7 +13069,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -13652,7 +13652,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
         "core-util-is": "~1.0.0",
@@ -16471,7 +16471,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
@@ -18867,7 +18867,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {


### PR DESCRIPTION
I've reported your changes from the branch "feature-multi-tenancy", and then i've done some changes like:
- [`MultiTenancyImplementation.getTenant()`](https://github.com/ManyDesigns/Portofino/compare/feature%2Fmultitenancy2.0?diff=split&expand=1#diff-0774c69f625d99b5844ddd67c04d950c9185349df1b6f4ac7e1195e72d27be42R58) is a abstract method: i've done this because i felt that the base implementation is useless and, since you extract shiro from the portofino-core, it is no longer implementable.
- [`MultiTenancyImplementation implementation = implClass.getConstructor(Persistence.class).newInstance(this);`](https://github.com/ManyDesigns/Portofino/compare/feature%2Fmultitenancy2.0?diff=split&expand=1#diff-a534ebbabaf4858fb23b6555c42db04b433ffb11bc95d6df38ac94394f4c72a5R447) i've done this because it comes from my implementation of `MultiTenancyImplementation` which I am attaching. Maybe you can give me some advice on how can I modify my implementation without this shortcut :) The best thing maybe would be to have Spring dependency injection but at the moment i don't know hot to implement it, it is beyond my current knowledge of Portofino.


My implementation -> [here](https://pastebin.com/gkjdtM09)